### PR TITLE
fixed appending existing data at refresh

### DIFF
--- a/backend/handlers/projects_get.go
+++ b/backend/handlers/projects_get.go
@@ -7,9 +7,9 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func ProjectsGetAll(projects *repository.Projects) gin.HandlerFunc {
+func GetAll(projects *repository.Projects) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		results := projects.GetProjects()
+		results := projects.GetAll()
 		c.JSON(http.StatusOK, results)
 	}
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -12,7 +12,7 @@ func main() {
 
 	api := r.Group("/api")
 	api.GET("/ping", handlers.Ping())
-	api.GET("/projects", handlers.ProjectsGetAll(projects))
+	api.GET("/projects", handlers.GetAll(projects))
 
 	err := r.Run("0.0.0.0:8080")
 

--- a/backend/repository/project-repo.go
+++ b/backend/repository/project-repo.go
@@ -13,7 +13,10 @@ func New() *Projects {
 	return &Projects{}
 }
 
-func (r *Projects) GetProjects() []entities.Project {
-	database.GetDocuments(&r.Projects.Projects, "projects")
+func (r *Projects) GetAll() []entities.Project {
+	if len(r.Projects.Projects) == 0 {
+		database.GetDocuments(&r.Projects.Projects, "projects")
+	}
+
 	return r.Projects.Projects
 }


### PR DESCRIPTION
Bugged occurred at the project repo. Function would call database at every refresh so it would append the same projects to the existing array causing duplicate projects.